### PR TITLE
CIのエラーを修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -24,8 +24,6 @@ jobs:
       - name: Scan for known security vulnerabilities in gems used
         run: bin/bundler-audit
       
-  scan_js:
-    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
@@ -37,7 +35,6 @@ jobs:
           bundler-cache: true
 
       - name: Scan for security vulnerabilities in JavaScript dependencies
-        run: bin/importmap audit
 
   lint:
     runs-on: ubuntu-latest

--- a/compose.yml
+++ b/compose.yml
@@ -15,6 +15,7 @@ services:
       retries: 10
 
   web:
+    init: true 
     build:
       context: .
       dockerfile: Dockerfile.dev


### PR DESCRIPTION
## 概要
Rails8構成の本プロジェクトにおいて、CIでbin/importmap auditが実行されエラーとなっていた問題を修正しました。

## 目的
importmapを使用していない構成にもかかわらず、CIでimportmapの監査が実行されていたため、
不要なエラーでCIが失敗しないようにすることを目的としている。

## 作業内容
- GitHub Actions の workflow を修正

## 確認事項
- CI（GitHub Actions）が正常に完了すること
- Rails8構成でimportmapを使用していない場合でもエラーにならないこと

## 備考
- 本プロジェクトでは importmap を使用していないため、CI構成を現状に合わせて調整しています