### PR TITLE
Dockerファイルの修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,5 +73,5 @@ COPY --chown=rails:rails --from=build /rails /rails
 ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 
 # Start server via Thruster by default, this can be overwritten at runtime
-EXPOSE 80
-CMD ["./bin/thrust", "./bin/rails", "server"]
+EXPOSE 3000
+CMD ["bash", "-lc", "bundle exec rails server -b 0.0.0.0 -p ${PORT:-3000}"]


### PR DESCRIPTION
## 概要
Renderデプロイ対応のため、Dockerfileの起動設定を修正しました。

## 目的
- Render環境での正常起動を保証するため

## 変更内容
- Railsサーバーを直接起動するよう変更
- `$PORT` を使用するよう修正
- `EXPOSE 80` → `EXPOSE 3000` に変更

## 確認事項
- ローカルでのビルドが成功すること
- Render上で正常にデプロイ・起動すること

## 備考
Render特有のポート仕様に対応するための修正です。
本番デプロイ安定化を目的としています。
