### PR TITLE
レーダーチャートの実装

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,6 +21,8 @@
     <%# Includes all stylesheet files in app/assets/stylesheets %>
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   </head>
 
   <body class="min-h-screen bg-white text-slate-900 pb-16">

--- a/app/views/shops/show.html.erb
+++ b/app/views/shops/show.html.erb
@@ -124,6 +124,65 @@
             </div>
           <% end %>
 
+          <!-- レーダーチャート -->
+          <% radar_values = [review.meat_taste, review.sauce_taste, review.vegetable_amount, review.bread_compatibility, review.value_for_money] %>
+          <% if radar_values.any?(&:present?) %>
+            <div class="flex justify-center">
+              <div class="w-full" style="max-width: 280px;">
+                <canvas id="radar-chart-<%= review.id %>"></canvas>
+              </div>
+            </div>
+            <script>
+              document.addEventListener("DOMContentLoaded", function() {
+                new Chart(document.getElementById("radar-chart-<%= review.id %>"), {
+                  type: "radar",
+                  data: {
+                    labels: ["肉の味", "ソース", "野菜の量", "パン相性", "価格満足度"],
+                    datasets: [{
+                      data: [<%= radar_values.map { |v| v || 0 }.join(", ") %>],
+                      backgroundColor: "rgba(245, 158, 11, 0.3)",
+                      borderColor: "rgba(194, 65, 12, 0.9)",
+                      borderWidth: 2.5,
+                      pointBackgroundColor: "rgba(194, 65, 12, 1)",
+                      pointBorderColor: "#fff",
+                      pointBorderWidth: 1,
+                      pointRadius: 4,
+                      fill: true
+                    }]
+                  },
+                  options: {
+                    responsive: true,
+                    maintainAspectRatio: true,
+                    plugins: { legend: { display: false } },
+                    scales: {
+                      r: {
+                        min: 0,
+                        max: 5,
+                        ticks: {
+                          stepSize: 1,
+                          display: false
+                        },
+                        grid: {
+                          color: "rgba(217, 119, 6, 0.3)",
+                          lineWidth: 1.5,
+                          circular: false
+                        },
+                        angleLines: {
+                          color: "rgba(217, 119, 6, 0.3)",
+                          lineWidth: 1.5
+                        },
+                        pointLabels: {
+                          font: { size: 12, weight: "bold" },
+                          color: "#44403c"
+                        }
+                      }
+                    }
+                  }
+                });
+              });
+            </script>
+          <% end %>
+
           <!-- 総合評価バー -->
           <div class="bg-amber-50 rounded-xl px-4 py-3 border border-amber-200">
             <div class="flex items-center justify-between mb-2">

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -84,11 +84,11 @@ Shop.find_each do |shop|
       meat_type: meat_types.sample,
       sauce_type: sauce_types.sample,
       overall_score: rand(1..10),
-      meat_taste: rand(1..10),
-      sauce_taste: rand(1..10),
-      vegetable_amount: rand(1..10),
-      bread_compatibility: rand(1..10),
-      value_for_money: rand(1..10),
+      meat_taste: rand(1..5),
+      sauce_taste: rand(1..5),
+      vegetable_amount: rand(1..5),
+      bread_compatibility: rand(1..5),
+      value_for_money: rand(1..5),
       comment: comments[i]
     )
   end


### PR DESCRIPTION
## 概要
店舗詳細ページの各レビューカードに、5つの評価項目をレーダーチャートで視覚的に表示するUIを実装しました。

## 目的
評価項目の数値だけでは特徴が掴みにくいため、Chart.jsのレーダーチャートで見やすく体系的に表示し、レビューの評価バランスを一目で把握できるようにする。

## 作業内容
- Chart.js CDNを追加
- 既存5段階評価表示の後に、5項目（肉の味・ソース・野菜の量・パン相性・価格満足度）のレーダーチャートを追加
- デザインはオレンジ系カラーで統一

## 確認事項
- [ ] 店舗詳細ページの各レビューカードにレーダーチャートが表示されること
- [ ] チャートの5項目の値が5段階評価グリッドのドット表示と一致していること
- [ ] スマホ幅でもチャートが崩れずに表示されること
- [ ] 評価値が全てnilのレビューではチャートが非表示であること

## 関連issue
- close #52

## 備考
- Chart.jsはCDN経由で読み込んでおり、gem追加やビルド設定の変更は不要
- チャートのスケールは最大5（5段階評価に合わせて）