### PR TITLE
ニックネーム設定機能の追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,4 +4,13 @@ class ApplicationController < ActionController::Base
 
   # Changes to the importmap will invalidate the etag for HTML responses
   stale_when_importmap_changes
+
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  private
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [ :nickname ])
+    devise_parameter_sanitizer.permit(:account_update, keys: [ :nickname ])
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,10 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_many :reviews, dependent: :destroy
+
+  validates :nickname, length: { maximum: 20 }, allow_blank: true
+
+  def display_name
+    nickname.presence || "名称未設定"
+  end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -5,7 +5,8 @@
     <div class="absolute inset-0 bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20width%3D%2260%22%20height%3D%2260%22%20viewBox%3D%220%200%2060%2060%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cg%20fill%3D%22%23ffffff%22%20fill-opacity%3D%220.08%22%3E%3Cpath%20d%3D%22M36%2034v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6%2034v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6%204V0H4v4H0v2h4v4h2V6h4V4H6z%22%2F%3E%3C%2Fg%3E%3C%2Fg%3E%3C%2Fsvg%3E')] opacity-30"></div>
     <div class="relative">
       <h1 class="text-3xl font-black tracking-tight">アカウント</h1>
-      <p class="mt-2 text-amber-200 text-sm font-medium"><%= resource.email %></p>
+      <p class="mt-1 text-amber-50 text-base font-bold"><%= resource.display_name %></p>
+      <p class="mt-1 text-amber-200 text-sm font-medium"><%= resource.email %></p>
     </div>
   </div>
 
@@ -22,6 +23,13 @@
         <%= render "devise/shared/error_messages", resource: resource %>
 
         <div class="space-y-4">
+          <div>
+            <%= f.label :nickname, class: "block text-sm font-bold text-stone-700 mb-1" %>
+            <p class="text-xs text-stone-400 mb-1">レビュー時に表示されます（任意・20文字以内）</p>
+            <%= f.text_field :nickname, autocomplete: "nickname",
+                class: "w-full px-4 py-3 rounded-xl border-2 border-stone-200 bg-amber-50 text-stone-800 text-sm focus:outline-none focus:border-amber-400 focus:ring-1 focus:ring-amber-400 transition-colors" %>
+          </div>
+
           <div>
             <%= f.label :email, class: "block text-sm font-bold text-stone-700 mb-1" %>
             <%= f.email_field :email, autofocus: true, autocomplete: "email",

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -19,6 +19,13 @@
 
         <div class="space-y-4">
           <div>
+            <%= f.label :nickname, class: "block text-sm font-bold text-stone-700 mb-1" %>
+            <p class="text-xs text-stone-400 mb-1">レビュー時に表示されます（任意・20文字以内）</p>
+            <%= f.text_field :nickname, autocomplete: "nickname",
+                class: "w-full px-4 py-3 rounded-xl border-2 border-stone-200 bg-amber-50 text-stone-800 text-sm focus:outline-none focus:border-amber-400 focus:ring-1 focus:ring-amber-400 transition-colors" %>
+          </div>
+
+          <div>
             <%= f.label :email, class: "block text-sm font-bold text-stone-700 mb-1" %>
             <%= f.email_field :email, autofocus: true, autocomplete: "email",
                 class: "w-full px-4 py-3 rounded-xl border-2 border-stone-200 bg-amber-50 text-stone-800 text-sm focus:outline-none focus:border-amber-400 focus:ring-1 focus:ring-amber-400 transition-colors" %>

--- a/app/views/shops/show.html.erb
+++ b/app/views/shops/show.html.erb
@@ -72,10 +72,10 @@
         <div class="flex items-center justify-between px-5 py-4 border-b border-stone-100">
           <div class="flex items-center gap-2">
             <span class="inline-flex items-center justify-center w-9 h-9 rounded-full bg-stone-900 text-amber-50 text-sm font-black">
-              <%= review.user.email.first.upcase %>
+              <%= review.user.display_name.first.upcase %>
             </span>
             <div>
-              <p class="text-sm font-bold text-stone-800"><%= review.user.email.split('@').first %></p>
+              <p class="text-sm font-bold text-stone-800"><%= review.user.display_name %></p>
               <p class="text-xs text-amber-700"><%= review.created_at.strftime("%Y/%m/%d") %></p>
             </div>
           </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,6 +4,7 @@ ja:
       user: ユーザー
     attributes:
       user:
+        nickname: ニックネーム
         email: メールアドレス
         password: パスワード
         password_confirmation: パスワード（確認用）

--- a/db/migrate/20260306052818_add_nickname_to_users.rb
+++ b/db/migrate/20260306052818_add_nickname_to_users.rb
@@ -1,0 +1,5 @@
+class AddNicknameToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :nickname, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_22_074812) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_06_052818) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -79,6 +79,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_22_074812) do
     t.datetime "created_at", null: false
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
+    t.string "nickname"
     t.datetime "remember_created_at"
     t.datetime "reset_password_sent_at"
     t.string "reset_password_token"


### PR DESCRIPTION
## 概要                                                                 
ユーザーがニックネームを設定できる機能を追加しました。

## 目的
レビュー表示時にメールアドレスではなくニックネームを表示することで、
ユーザーのプライバシーを保護し、コミュニティとしての親しみやすさを向
上させるため

## 作業内容
- usersテーブルにnicknameカラムを追加
- Userモデルにバリデーションを追加
- Deviseのストロングパラメータ設定を追加
- 新規登録・アカウント編集フォームにニックネーム入力欄を追加
- アカウント編集画面のヘッダーにニックネームを表示
- 店舗詳細ページのレビュー表示をニックネーム対応に変更（未設定時は「
名称未設定」と表示）
- 日本語翻訳ファイルにニックネームの翻訳を追加

## 確認事項
- [ ] 新規登録時にニックネームあり・なし両方で登録できること
- [ ] アカウント編集画面でニックネームを変更・削除できること
- [ ] 21文字以上のニックネームでバリデーションエラーが表示されること
- [ ] ニックネーム設定済みユーザーのレビューにニックネームが表示されること
- [ ] ニックネーム未設定ユーザーのレビューに「名称未設定」と表示されること

## 関連issue
-

## 備考
- ニックネームは任意項目のため、既存ユーザーへの影響なし